### PR TITLE
Fixed Faraday bug in connection/basic.rb

### DIFF
--- a/lib/api_client/connection/basic.rb
+++ b/lib/api_client/connection/basic.rb
@@ -1,5 +1,6 @@
 # Faraday for making requests
 require 'faraday'
+require 'faraday/request/url_encoded'
 
 module ApiClient
 

--- a/lib/api_client/version.rb
+++ b/lib/api_client/version.rb
@@ -1,3 +1,3 @@
 module ApiClient
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
In Faraday `0.9.0.rc5` the author apparently removed one require (`faraday/request/url_encoded`) and it causes an error in `connection/basic.rb`:

```
/xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/connection/basic.rb:20:in `finalize_handler': uninitialized constant Faraday::Request::UrlEncoded (NameError)
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/connection/basic.rb:15:in `create_handler'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/connection/abstract.rb:16:in `initialize'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/scope.rb:27:in `new'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/scope.rb:27:in `connection'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/scope.rb:83:in `request'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/scope.rb:88:in `get'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/scope.rb:72:in `block in fetch'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/mxxxins/scoping.rb:29:in `scoped'
        from (eval):2:in `scoped'
        from /xxx/1.9.3-p392/lib/ruby/gems/1.9.1/gems/api_client-0.5.0/lib/api_client/scope.rb:71:in `fetch
```

I've added an explicit require and tested against Faraday 0.9.0.rc5 and Faraday 0.8.8.
Also version-bumpted it.
