### PR TITLE
add config class and configuration for default headers

### DIFF
--- a/lib/api_client.rb
+++ b/lib/api_client.rb
@@ -4,7 +4,16 @@ module ApiClient
     attr_accessor :logger
   end
 
+  def self.configure(&block)
+    yield(config)
+  end
+
+  def self.config
+    @config ||= ::ApiClient::Config.new
+  end
+
   autoload :Base,           "api_client/base"
+  autoload :Config,         "api_client/config"
   autoload :Errors,         "api_client/errors"
   autoload :Scope,          "api_client/scope"
   autoload :Utils,          "api_client/utils"

--- a/lib/api_client/config.rb
+++ b/lib/api_client/config.rb
@@ -1,0 +1,7 @@
+require "hashie"
+
+module ApiClient
+  class Config < ::Hashie::Dash
+    property :default_headers, :default => {}
+  end
+end

--- a/lib/api_client/scope.rb
+++ b/lib/api_client/scope.rb
@@ -13,7 +13,7 @@ module ApiClient
     def initialize(scopeable)
       @scopeable  = scopeable
       @params     = {}
-      @headers    = {}
+      @headers    = ApiClient.config.default_headers.dup
       @options    = {}
       @hooks      = @scopeable.connection_hooks || []
       @scopeable.default_scopes.each do |default_scope|

--- a/spec/api_client/config_spec.rb
+++ b/spec/api_client/config_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe ApiClient::Config do
+  subject { described_class.new }
+
+  it "inherits from Hashie::Dash" do
+    described_class.should inherit_from(Hashie::Dash)
+  end
+  its(:default_headers) { should be_a(Hash) }
+end


### PR DESCRIPTION
Per basecrm/basecrm#17

1) Added a config class where you can specify default headers, which can get around the issue of the headers not being passed down when instantiating resources.

So now I can do:

``` ruby
ApiClient.configure do |config|
  config.default_headers = {"X-Pipejump-Auth"=> BASE_API_TOKEN, "X-Futuresimple-Token"=> BASE_API_TOKEN}
end
```

And not be forced into instantiating client sessions, which like I said is very useful for single organizations. Particularly when working with the api objects directly i.e.

``` ruby
BaseCrm::Lead.create({:last_name => "whatever"})
```
