### PR TITLE
add support for updating attributes in place

### DIFF
--- a/lib/api_client/resource/base.rb
+++ b/lib/api_client/resource/base.rb
@@ -35,9 +35,15 @@ module ApiClient
       end
 
       def save
-        self.persisted? ? remote_update : remote_create
-      end
+        result = self.persisted? ? remote_update : remote_create
 
+        result.each_pair do |k,v|
+          __send__("#{k}=", v)
+        end if result
+
+        self
+      end
+      
       def destroy
         get_scope.destroy(self.id)
       end


### PR DESCRIPTION
Currently save has no support for updating the resource attributes in place i.e.

``` ruby
lead = session.leads.new({:last_name => "asdasd"})
lead.save
puts lead
#would yield
Lead last_name: "asdasd"
```

Now it maps the attributes of the result back to the original instance
