### PR TITLE
Make ApiClient::Base marshallable by not storing proc as instance var

### DIFF
--- a/lib/api_client/scope.rb
+++ b/lib/api_client/scope.rb
@@ -15,7 +15,6 @@ module ApiClient
       @params     = {}
       @headers    = {}
       @options    = {}
-      @hooks      = @scopeable.connection_hooks || []
       @scopeable.default_scopes.each do |default_scope|
         self.instance_eval(&default_scope)
       end
@@ -24,7 +23,8 @@ module ApiClient
     def connection
       klass       = Connection.const_get((@adapter || Connection.default).to_s.capitalize)
       @connection = klass.new(@endpoint , @options || {})
-      @hooks.each { |hook| hook.call(@connection) }
+      hooks      = @scopeable.connection_hooks || []
+      hooks.each { |hook| hook.call(@connection) }
       @connection
     end
 

--- a/spec/api_client/base/marshalling_spec.rb
+++ b/spec/api_client/base/marshalling_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "Marshaling of ApiClient objects" do
+  ConnectionProc = Proc.new {}
+  AlwaysProc = Proc.new {}
+
+  class Entity < ApiClient::Base
+    connection &ConnectionProc
+    always &AlwaysProc
+
+    def mutated_state?
+      @state == "mutated"
+    end
+
+    def mutate_state!
+      @state = "mutated"
+    end
+  end
+
+  it "is marshallable by default" do
+    scope = Entity.params(:foo => 1).headers("token" => "aaa").options("some" => "option")
+    entity = scope.build :key => "value"
+
+    entity.mutated_state?.should == false
+    entity.mutate_state!
+    entity.mutated_state?.should == true
+
+    reloaded = Marshal.load(Marshal.dump(entity))
+
+    reloaded.should == entity
+    reloaded.mutated_state?.should == true
+  end
+end


### PR DESCRIPTION
Since most Rails cache backends serialize objects using the Marshal
module it is desired that instances of api client objects are
marshalable by default.

Until now storing a connection hook (a proc) caused the following error
TypeError:
    no _dump_data is defined for class Proc