### PR TITLE
Add status codes to messages of response error exceptions

### DIFF
--- a/lib/api_client/errors.rb
+++ b/lib/api_client/errors.rb
@@ -13,16 +13,33 @@ module ApiClient
 
     class ConnectionFailed < ApiClientError; end
     class Config < ApiClientError; end
-    class Unauthorized < ApiClientError; end
-    class Forbidden < ApiClientError; end
-    class NotFound < ApiClientError; end
-    class Redirect < ApiClientError; end
-    class BadRequest < ApiClientError; end
-    class Unsupported < ApiClientError; end
-    class Conflict < ApiClientError; end
-    class ServerError < ApiClientError; end
-    class UnprocessableEntity < ApiClientError; end
-    class TooManyRequests < ApiClientError; end
+
+    class ApiClientResponseError < ApiClientError
+      def to_s
+        with_status_code_if_present(super)
+      end
+
+      private
+
+      def with_status_code_if_present(msg)
+        if response && response.respond_to?(:status)
+          msg += " (#{response.status})"
+        else
+          msg
+        end
+      end
+    end
+
+    class Unauthorized < ApiClientResponseError; end
+    class Forbidden < ApiClientResponseError; end
+    class NotFound < ApiClientResponseError; end
+    class Redirect < ApiClientResponseError; end
+    class BadRequest < ApiClientResponseError; end
+    class Unsupported < ApiClientResponseError; end
+    class Conflict < ApiClientResponseError; end
+    class ServerError < ApiClientResponseError; end
+    class UnprocessableEntity < ApiClientResponseError; end
+    class TooManyRequests < ApiClientResponseError; end
   end
 
 end

--- a/spec/api_client/connection/basic_spec.rb
+++ b/spec/api_client/connection/basic_spec.rb
@@ -96,42 +96,42 @@ describe ApiClient::Connection::Basic do
       @response.env[:status] = 401
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::Unauthorized, "ApiClient::Errors::Unauthorized")
+      }.should raise_error(ApiClient::Errors::Unauthorized, "ApiClient::Errors::Unauthorized (401)")
     end
 
     it "raises an ApiClient::Errors::Forbidden if status is 403" do
       @response.env[:status] = 403
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::Forbidden, "ApiClient::Errors::Forbidden")
+      }.should raise_error(ApiClient::Errors::Forbidden, "ApiClient::Errors::Forbidden (403)")
     end
 
     it "raises an ApiClient::Errors::NotFound if status is 404" do
       @response.env[:status] = 404
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::NotFound, "ApiClient::Errors::NotFound")
+      }.should raise_error(ApiClient::Errors::NotFound, "ApiClient::Errors::NotFound (404)")
     end
 
     it "raises an ApiClient::Errors::BadRequest if status is 400" do
       @response.env[:status] = 400
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::BadRequest, "ApiClient::Errors::BadRequest")
+      }.should raise_error(ApiClient::Errors::BadRequest, "ApiClient::Errors::BadRequest (400)")
     end
 
     it "raises an ApiClient::Errors::Unsupported if status is 406" do
       @response.env[:status] = 406
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::Unsupported, "ApiClient::Errors::Unsupported")
+      }.should raise_error(ApiClient::Errors::Unsupported, "ApiClient::Errors::Unsupported (406)")
     end
 
     it "raises an ApiClient::Errors::Conflict if status is 409" do
       @response.env[:status] = 409
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::Conflict, "ApiClient::Errors::Conflict")
+      }.should raise_error(ApiClient::Errors::Conflict, "ApiClient::Errors::Conflict (409)")
     end
 
     it "raises an ApiClient::Errors::Unsupported if status is 422" do
@@ -154,14 +154,14 @@ describe ApiClient::Connection::Basic do
       @response.env[:response_headers] = { 'Location' => location }
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::Redirect, location)
+      }.should raise_error(ApiClient::Errors::Redirect, Regexp.new(location))
     end
 
     it "raises an ApiClient::Errors::ServerError if status is 500..599" do
       @response.env[:status] = 502
       lambda {
         @instance.send :handle_response, request, @response
-      }.should raise_error(ApiClient::Errors::ServerError, "ApiClient::Errors::ServerError")
+      }.should raise_error(ApiClient::Errors::ServerError, "ApiClient::Errors::ServerError (502)")
     end
 
   end


### PR DESCRIPTION
This is especially useful for expection classes that may represent
different HTTP response statuses (e.g. ServerError).