### PR TITLE
Force utf-8 encoding in debug logs

### DIFF
--- a/lib/api_client/connection/middlewares/request/logger.rb
+++ b/lib/api_client/connection/middlewares/request/logger.rb
@@ -14,6 +14,7 @@ class ApiClient::Connection::Middlewares::Request::Logger < Faraday::Middleware
     gather_response_debug_lines(response, taken_sec, debug_lines) if response && should_log_details
 
     if should_log_details
+      debug_lines.each { |line| line.encode!("UTF-8", invalid: :replace, undef: :replace) }
       @logger.debug { debug_lines.join("\n") }
     else
       @logger.info { "#{env[:method].to_s.upcase} #{env[:url]}: #{"%.4f" % taken_sec} seconds" }


### PR DESCRIPTION
Faraday env might contain strings of different encodings which
result in Encoding::CompatibilityError when `join("\n")` is called.