### PR TITLE
Introduced PATCH requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 coverage
 examples/config.rb
 *.sw[a-z]
+.idea/*

--- a/lib/api_client/base.rb
+++ b/lib/api_client/base.rb
@@ -11,7 +11,7 @@ module ApiClient
       extend ApiClient::Mixins::Delegation
       extend ApiClient::Mixins::Configuration
 
-      delegate :fetch, :get, :put, :post, :delete, :headers, :endpoint, :options, :adapter, :params, :raw, :to => :scope
+      delegate :fetch, :get, :put, :post, :patch, :delete, :headers, :endpoint, :options, :adapter, :params, :raw, :to => :scope
 
       dsl_accessor :format, :namespace
 

--- a/lib/api_client/connection/abstract.rb
+++ b/lib/api_client/connection/abstract.rb
@@ -38,6 +38,17 @@ module ApiClient
       def post(path, data = {}, headers = {})
       end
 
+      #### ApiClient::Connection::Abstract#patch
+      # Performs a PATCH request
+      # Accepts three parameters:
+      #
+      # * path - the path request should go to
+      # * data - (optional) data sent in the request
+      # * headers - (optional) headers sent along in the request
+      #
+      def patch(path, data = {}, headers = {})
+      end
+
       #### ApiClient::Connection::Abstract#put
       # Performs a PUT request
       # Accepts three parameters:

--- a/lib/api_client/connection/basic.rb
+++ b/lib/api_client/connection/basic.rb
@@ -43,6 +43,19 @@ module ApiClient
         exec_request(:post, path, data, headers)
       end
 
+      #### ApiClient::Connection::Abstract#patch
+      # Performs a PATCH request
+      # Accepts three parameters:
+      #
+      # * path - the path request should go to
+      # * data - (optional) data sent in the request
+      # * headers - (optional) headers sent along in the request
+      #
+      # This method automatically adds the application token header
+      def patch(path, data = {}, headers = {})
+        exec_request(:patch, path, data, headers)
+      end
+
       #### ApiClient::Connection::Abstract#put
       # Performs a PUT request
       # Accepts three parameters:

--- a/lib/api_client/connection/middlewares/request/logger.rb
+++ b/lib/api_client/connection/middlewares/request/logger.rb
@@ -7,9 +7,9 @@ class ApiClient::Connection::Middlewares::Request::Logger < Faraday::Middleware
 
     gather_request_debug_lines(env, debug_lines) if should_log_details
 
-    start = current_stamp_millisec
+    start = CurrentTimestamp.milis
     response = @app.call(env)
-    taken_sec = (current_stamp_millisec - start) / 1000.0
+    taken_sec = (CurrentTimestamp.milis - start) / 1000.0
 
     gather_response_debug_lines(response, taken_sec, debug_lines) if response && should_log_details
 
@@ -46,7 +46,19 @@ class ApiClient::Connection::Middlewares::Request::Logger < Faraday::Middleware
     debug_lines
   end
 
-  def current_stamp_millisec
-    Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  class CurrentTimestamp
+    class << self
+      version = RUBY_VERSION.split('.').map(&:to_i)
+
+      if (version[0] < 2) || (version[0] == 2 && version[1] < 2)
+        def milis
+          (Time.now.to_f * 1000).to_i
+        end
+      else
+        def milis
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+        end
+      end
+    end
   end
 end

--- a/lib/api_client/scope.rb
+++ b/lib/api_client/scope.rb
@@ -97,6 +97,10 @@ module ApiClient
       request(:post, path, options)
     end
 
+    def patch(path, options = {})
+      request(:patch, path, options)
+    end
+
     def put(path, options = {})
       request(:put, path, options)
     end

--- a/spec/api_client/base/delegation_spec.rb
+++ b/spec/api_client/base/delegation_spec.rb
@@ -5,7 +5,7 @@ describe ApiClient::Base do
   it "delegates methods to scope" do
     scope = double
     ApiClient::Base.stub(:scope).and_return(scope)
-    [:fetch, :get, :put, :post, :delete, :headers, :endpoint, :options, :adapter, :params, :raw].each do |method|
+    [:fetch, :get, :put, :post, :patch, :delete, :headers, :endpoint, :options, :adapter, :params, :raw].each do |method|
       scope.should_receive(method)
       ApiClient::Base.send(method)
     end

--- a/spec/api_client/connection/basic_spec.rb
+++ b/spec/api_client/connection/basic_spec.rb
@@ -58,6 +58,14 @@ describe ApiClient::Connection::Basic do
       @instance.post "/home", @params, @headers
     end
 
+    it "can perform PATCH requests" do
+      @instance.handler.
+        should_receive(:run_request).
+        with(:patch, '/home', @params, @headers).
+        and_return(@response)
+      @instance.patch "/home", @params, @headers
+    end
+
     it "can perform PUT requests" do
       @instance.handler.
         should_receive(:run_request).

--- a/spec/api_client/scope_spec.rb
+++ b/spec/api_client/scope_spec.rb
@@ -147,6 +147,11 @@ describe ApiClient::Scope do
       result.should == {"a"=> "1"}
     end
 
+    it "makes a PATCH request" do
+      result = test_request :patch
+      result.should == {"a"=> "1"}
+    end
+
     it "makes a PUT request" do
       result = test_request :put
       result.should == {"a"=> "1"}


### PR DESCRIPTION
- Introduced `PATCH` requests.
- Brought back ruby `< 2.1` compatibility. `Process::CLOCK_MONOTONIC` is not present until `ruby 2.2`. There is a breaking change since `0.5.16`.

https://gitlab.com/gitlab-org/gitlab-shell/issues/69

@iaintshine 👀