### PR TITLE
Compatibility maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ before_install:
   - gem install bundler -v 1.11.2
 script: bundle exec rspec spec
 rvm:
-  - 1.8.7
+  - jruby-1.7.2
   - 1.9.3
-  - 2.1.8
-  - 2.3.0
+  - 2.1.9
+  - 2.2.10
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3

--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # Declare runtime dependencies here:
   def s.add_runtime_dependencies(method)
     if RUBY_PLATFORM == "java"
-      send method, 'json_pure'
+      send method, 'jrjackson'
     else
       send method, 'yajl-ruby'
     end

--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -17,12 +17,11 @@ Gem::Specification.new do |s|
   def s.add_runtime_dependencies(method)
     if RUBY_PLATFORM == "java"
       send method, 'json_pure'
-      send method, 'hashie', [">= 2.0.5"]
     else
       send method, 'yajl-ruby'
-      send method, 'hashie', RUBY_VERSION =~ /1\.8/ ? [">= 2.0.5", "<= 3.4.2"] : [">= 2.0.5"]
     end
 
+    send method, 'hashie', [">= 2.0.5"]
     send method, 'faraday', [">= 0.8.1"]
     send method, 'multi_json', [">= 1.6.1"]
   end
@@ -31,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '2.14.1'
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then


### PR DESCRIPTION
**CI pipeline**
1. Added jruby
2. Removed ruby 1.8.7 (looking at build history, seems like it does not support this ruby versions since few releases)
3. Added / Bump minor versions for MRI: 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x

**JRuby support**
1. Replace `json_pure` with `jrjackson`, which was the only difference between master and `jruby` branch, so we don't need `jruby` branch any more.

https://travis-ci.org/futuresimple/api_client/builds/547137788