### PR TITLE
Restrict faraday version to < 1.0.0

### DIFF
--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     end
 
     send method, 'hashie', [">= 2.0.5"]
-    send method, 'faraday', [">= 0.8.1"]
+    send method, 'faraday', [">= 0.8.1", "< 1.0.0"]
     send method, 'multi_json', [">= 1.6.1"]
   end
 


### PR DESCRIPTION
This gem uses error classes in way removed from 1.0.0. See

https://github.com/lostisland/faraday/blob/master/UPGRADING.md